### PR TITLE
Root folder note

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -197,8 +197,8 @@ export default class Waypoint extends Plugin {
 				}).filter(child => this.settings.showFolderNotes || child.name !== node.name + ".md");
 				if (children.length > 0) {
 					text += "\n" + (await Promise.all(children.map(child => this.getFileTreeRepresentation(child, indentLevel + 1))))
-					.filter(Boolean)
-					.join("\n");
+						.filter(Boolean)
+						.join("\n");
 				}
 				return text;
 			} else {
@@ -295,7 +295,7 @@ export default class Waypoint extends Plugin {
 
 	log(message: string) {
 		if (this.settings.debugLogging) {
-			console.log(message);			
+			console.log(message);
 		}
 	}
 

--- a/main.ts
+++ b/main.ts
@@ -56,6 +56,17 @@ export default class Waypoint extends Plugin {
 
 		// This adds a settings tab so the user can configure various aspects of the plugin
 		this.addSettingTab(new WaypointSettingsTab(this.app, this));
+
+		// Add in a hotkey to update the waypoint
+		this.addCommand({
+			id: "update-waypoint",
+			name: "Update waypoint in current file",
+			hotkeys: [{
+				modifiers: ["Ctrl"],
+				key: "w"
+			}],
+			callback: () => { this.updateWaypoint(this.app.workspace.getActiveFile()) }
+		})
 	}
 
 	onunload() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "waypoint",
-	"version": "1.0.1",
+	"version": "1.1.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "waypoint",
-			"version": "1.0.1",
+			"version": "1.1.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/codemirror": "^5.60.5",


### PR DESCRIPTION
As mentioned in #20. Root folder notes are the same as any other folder notes, with the root file name as the parent of the TOC. The root folder is saved in settings and ued if the root waypoint is requested ([here](https://github.com/RosiePuddles/Waypoint/commit/ff767812a3fd8e39781340b5b66909d07684c019#diff-564c860307257bfac9176f554a35aa858c350a59d75c0dcd0a5d63a480805bd0R237)) ([ff76781](https://github.com/RosiePuddles/Waypoint/commit/ff767812a3fd8e39781340b5b66909d07684c019))

This also adds in the ability to ignore certain folders ([49197fd](https://github.com/RosiePuddles/Waypoint/commit/49197fd31bd5aee208cf7f9c2a768e0c3a4b254b)).

Also, similarly to #12, a hotkey has been added to update the waypoint in the current file. This has limited use but can be useful is something were to go wrong and need forcefully fixing. ([568f1cb](https://github.com/RosiePuddles/Waypoint/commit/568f1cb23b26ed72d4a7fdd9e7a4212db7388549))

Some formatting was also done ([eceaa83](https://github.com/RosiePuddles/Waypoint/commit/eceaa837176e8002b13c30a84fd505064ed10b17)). Removing trailing whitespace and updating `package-lock.json` version number