### PR TITLE
Support writing markdown links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "waypoint",
-	"version": "1.0.1",
+	"version": "1.1.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "waypoint",
-			"version": "1.0.1",
+			"version": "1.1.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/codemirror": "^5.60.5",


### PR DESCRIPTION
Adds support for standard markdown links (with proper URI encoding). The Obsidian plugin API does not support looking at user preferences, so the setting for link format has been added as a plugin setting instead. Defaults to WikiLinks because WikiLinks are cool.