### PR TITLE
Fix regular markdown link generation

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -147,10 +147,9 @@ export default class Waypoint extends Plugin {
 	 * @returns The string representation of the tree, or null if the node is not a file or folder
 	 */
 	async getFileTreeRepresentation(root_node: TFolder, cur_node: TAbstractFile, indentLevel: number, topLevel = false): Promise<string>|null {
-		let pathFromRootNode = function() {
-			let prefix_len = root_node.path.length;
-			let link = cur_node.path.substring(prefix_len);
-			return `./${encodeURI(link)}`
+		let pathFromRootNode = function(node: TAbstractFile) {
+			let prefix_len = root_node.path.length + 1;
+			return `./${encodeURI(node.path.substring(prefix_len))}`;
 		};
 		const bullet = "	".repeat(indentLevel) + "-";
 		if (cur_node instanceof TFile) {
@@ -158,7 +157,7 @@ export default class Waypoint extends Plugin {
 				if (this.settings.useWikiLinks) {
 					return `${bullet} [[${cur_node.basename}]]`;
 				} else {
-					return `${bullet} [${cur_node.basename}](${pathFromRootNode()})`;
+					return `${bullet} [${cur_node.basename}](${pathFromRootNode(cur_node)})`;
 				}
 			}
 			return null;
@@ -169,7 +168,7 @@ export default class Waypoint extends Plugin {
 				if (this.settings.useWikiLinks) {
 					text = `${bullet} **[[${folderNote.basename}]]**`;
 				} else {
-					text = `${bullet} **[${folderNote.basename}](./${pathFromRootNode()})**`;
+					text = `${bullet} **[${folderNote.basename}](${pathFromRootNode(folderNote)})**`;
 				}
 				if (!topLevel) {
 					if (this.settings.stopScanAtFolderNotes) {

--- a/main.ts
+++ b/main.ts
@@ -141,7 +141,7 @@ export default class Waypoint extends Plugin {
 	/**
 	 * Generate a file tree representation of the given folder.
 	 * @param root_node Folder for which we are getting the file tree representation for
-	 * @param cur_node The node to generate the tree from
+	 * @param cur_node The current node in our recursive descent
 	 * @param indentLevel How many levels of indentation to draw
 	 * @param topLevel Whether this is the top level of the tree or not
 	 * @returns The string representation of the tree, or null if the node is not a file or folder

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "waypoint",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "waypoint",
-			"version": "1.1.0",
+			"version": "1.2.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/codemirror": "^5.60.5",
@@ -15,44 +15,26 @@
 				"@typescript-eslint/parser": "^5.2.0",
 				"builtin-modules": "^3.2.0",
 				"esbuild": "0.13.12",
-				"obsidian": "^0.13.26",
+				"obsidian": "^0.15.3",
 				"tslib": "2.3.1",
 				"typescript": "4.4.4"
 			}
 		},
-		"node_modules/@codemirror/rangeset": {
-			"version": "0.19.8",
-			"resolved": "https://registry.npmjs.org/@codemirror/rangeset/-/rangeset-0.19.8.tgz",
-			"integrity": "sha512-1vusIkxSD0vK5KQ22JO/4Ejfww5268PgM/CpKNBSpTpWZEFlZbmOPyRiY4HXO2oEzOpypbA/walMiNInWnrT0Q==",
-			"dev": true,
-			"dependencies": {
-				"@codemirror/state": "^0.19.0"
-			}
-		},
 		"node_modules/@codemirror/state": {
-			"version": "0.19.9",
-			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.19.9.tgz",
-			"integrity": "sha512-psOzDolKTZkx4CgUqhBQ8T8gBc0xN5z4gzed109aF6x7D7umpDRoimacI/O6d9UGuyl4eYuDCZmDFr2Rq7aGOw==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.1.0.tgz",
+			"integrity": "sha512-qbUr94DZTe6/V1VS7LDLz11rM/1t/nJxR1El4I6UaxDEdc0aZZvq6JCLJWiRmUf95NRAnDH6fhXn+PWp9wGCIg==",
 			"dev": true,
-			"dependencies": {
-				"@codemirror/text": "^0.19.0"
-			}
-		},
-		"node_modules/@codemirror/text": {
-			"version": "0.19.6",
-			"resolved": "https://registry.npmjs.org/@codemirror/text/-/text-0.19.6.tgz",
-			"integrity": "sha512-T9jnREMIygx+TPC1bOuepz18maGq/92q2a+n4qTqObKwvNMg+8cMTslb8yxeEDEq7S3kpgGWxgO1UWbQRij0dA==",
-			"dev": true
+			"peer": true
 		},
 		"node_modules/@codemirror/view": {
-			"version": "0.19.47",
-			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.47.tgz",
-			"integrity": "sha512-SfbagKvJQl5dtt+9wYpo9sa3ZkMgUxTq+/hXDf0KVwIx+zu3cJIqfEm9xSx6yXkq7it7RsPGHaPasApNffF/8g==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.0.2.tgz",
+			"integrity": "sha512-mnVT/q1JvKPjpmjXJNeCi/xHyaJ3abGJsumIVpdQ1nE1MXAyHf7GHWt8QpWMUvDiqF0j+inkhVR2OviTdFFX7Q==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
-				"@codemirror/rangeset": "^0.19.5",
-				"@codemirror/state": "^0.19.3",
-				"@codemirror/text": "^0.19.0",
+				"@codemirror/state": "^6.0.0",
 				"style-mod": "^4.0.0",
 				"w3c-keyname": "^2.2.4"
 			}
@@ -1521,9 +1503,9 @@
 			}
 		},
 		"node_modules/moment": {
-			"version": "2.29.1",
-			"resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-			"integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
+			"version": "2.29.3",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.29.3.tgz",
+			"integrity": "sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw==",
 			"dev": true,
 			"engines": {
 				"node": "*"
@@ -1543,15 +1525,17 @@
 			"peer": true
 		},
 		"node_modules/obsidian": {
-			"version": "0.13.26",
-			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-0.13.26.tgz",
-			"integrity": "sha512-7NLjrX8Yw5q3zROiOo52KUh4U0qEm3Oj5T62OhG/tbdHfq2/hqB2U93S/rquIseCbKUHnV4AVGIlYKGczvy8rg==",
+			"version": "0.15.3",
+			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-0.15.3.tgz",
+			"integrity": "sha512-vibepMCZd8iicuZPdd1dAg3I/lP3UrqIUn0aeT/vuIHkghcxcUOvc/cKFrX4JpFVux8dBET03HWqwOR/WF1r/A==",
 			"dev": true,
 			"dependencies": {
-				"@codemirror/state": "^0.19.6",
-				"@codemirror/view": "^0.19.31",
 				"@types/codemirror": "0.0.108",
-				"moment": "2.29.1"
+				"moment": "2.29.3"
+			},
+			"peerDependencies": {
+				"@codemirror/state": "^6.0.0",
+				"@codemirror/view": "^6.0.0"
 			}
 		},
 		"node_modules/obsidian/node_modules/@types/codemirror": {
@@ -1833,7 +1817,8 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.0.0.tgz",
 			"integrity": "sha512-OPhtyEjyyN9x3nhPsu76f52yUGXiZcgvsrFVtvTkyGRQJ0XK+GPc6ov1z+lRpbeabka+MYEQxOYRnt5nF30aMw==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
@@ -1933,7 +1918,8 @@
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.4.tgz",
 			"integrity": "sha512-tOhfEwEzFLJzf6d1ZPkYfGj+FWhIpBux9ppoP3rlclw3Z0BZv3N7b7030Z1kYth+6rDuAsXUFr+d0VE6Ed1ikw==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/which": {
 			"version": "2.0.2",
@@ -1976,39 +1962,21 @@
 		}
 	},
 	"dependencies": {
-		"@codemirror/rangeset": {
-			"version": "0.19.8",
-			"resolved": "https://registry.npmjs.org/@codemirror/rangeset/-/rangeset-0.19.8.tgz",
-			"integrity": "sha512-1vusIkxSD0vK5KQ22JO/4Ejfww5268PgM/CpKNBSpTpWZEFlZbmOPyRiY4HXO2oEzOpypbA/walMiNInWnrT0Q==",
-			"dev": true,
-			"requires": {
-				"@codemirror/state": "^0.19.0"
-			}
-		},
 		"@codemirror/state": {
-			"version": "0.19.9",
-			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.19.9.tgz",
-			"integrity": "sha512-psOzDolKTZkx4CgUqhBQ8T8gBc0xN5z4gzed109aF6x7D7umpDRoimacI/O6d9UGuyl4eYuDCZmDFr2Rq7aGOw==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.1.0.tgz",
+			"integrity": "sha512-qbUr94DZTe6/V1VS7LDLz11rM/1t/nJxR1El4I6UaxDEdc0aZZvq6JCLJWiRmUf95NRAnDH6fhXn+PWp9wGCIg==",
 			"dev": true,
-			"requires": {
-				"@codemirror/text": "^0.19.0"
-			}
-		},
-		"@codemirror/text": {
-			"version": "0.19.6",
-			"resolved": "https://registry.npmjs.org/@codemirror/text/-/text-0.19.6.tgz",
-			"integrity": "sha512-T9jnREMIygx+TPC1bOuepz18maGq/92q2a+n4qTqObKwvNMg+8cMTslb8yxeEDEq7S3kpgGWxgO1UWbQRij0dA==",
-			"dev": true
+			"peer": true
 		},
 		"@codemirror/view": {
-			"version": "0.19.47",
-			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.47.tgz",
-			"integrity": "sha512-SfbagKvJQl5dtt+9wYpo9sa3ZkMgUxTq+/hXDf0KVwIx+zu3cJIqfEm9xSx6yXkq7it7RsPGHaPasApNffF/8g==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.0.2.tgz",
+			"integrity": "sha512-mnVT/q1JvKPjpmjXJNeCi/xHyaJ3abGJsumIVpdQ1nE1MXAyHf7GHWt8QpWMUvDiqF0j+inkhVR2OviTdFFX7Q==",
 			"dev": true,
+			"peer": true,
 			"requires": {
-				"@codemirror/rangeset": "^0.19.5",
-				"@codemirror/state": "^0.19.3",
-				"@codemirror/text": "^0.19.0",
+				"@codemirror/state": "^6.0.0",
 				"style-mod": "^4.0.0",
 				"w3c-keyname": "^2.2.4"
 			}
@@ -3064,9 +3032,9 @@
 			}
 		},
 		"moment": {
-			"version": "2.29.1",
-			"resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-			"integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
+			"version": "2.29.3",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.29.3.tgz",
+			"integrity": "sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw==",
 			"dev": true
 		},
 		"ms": {
@@ -3083,15 +3051,13 @@
 			"peer": true
 		},
 		"obsidian": {
-			"version": "0.13.26",
-			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-0.13.26.tgz",
-			"integrity": "sha512-7NLjrX8Yw5q3zROiOo52KUh4U0qEm3Oj5T62OhG/tbdHfq2/hqB2U93S/rquIseCbKUHnV4AVGIlYKGczvy8rg==",
+			"version": "0.15.3",
+			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-0.15.3.tgz",
+			"integrity": "sha512-vibepMCZd8iicuZPdd1dAg3I/lP3UrqIUn0aeT/vuIHkghcxcUOvc/cKFrX4JpFVux8dBET03HWqwOR/WF1r/A==",
 			"dev": true,
 			"requires": {
-				"@codemirror/state": "^0.19.6",
-				"@codemirror/view": "^0.19.31",
 				"@types/codemirror": "0.0.108",
-				"moment": "2.29.1"
+				"moment": "2.29.3"
 			},
 			"dependencies": {
 				"@types/codemirror": {
@@ -3277,7 +3243,8 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.0.0.tgz",
 			"integrity": "sha512-OPhtyEjyyN9x3nhPsu76f52yUGXiZcgvsrFVtvTkyGRQJ0XK+GPc6ov1z+lRpbeabka+MYEQxOYRnt5nF30aMw==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"supports-color": {
 			"version": "7.2.0",
@@ -3355,7 +3322,8 @@
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.4.tgz",
 			"integrity": "sha512-tOhfEwEzFLJzf6d1ZPkYfGj+FWhIpBux9ppoP3rlclw3Z0BZv3N7b7030Z1kYth+6rDuAsXUFr+d0VE6Ed1ikw==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"which": {
 			"version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@typescript-eslint/parser": "^5.2.0",
 		"builtin-modules": "^3.2.0",
 		"esbuild": "0.13.12",
-		"obsidian": "^0.13.26",
+		"obsidian": "^0.15.3",
 		"tslib": "2.3.1",
 		"typescript": "4.4.4"
 	}


### PR DESCRIPTION
The regular markdown links are broken, and this fixes it. 

To verify that it was indeed broken before this patch, simply make nested folders (with folder notes) with waypoints. You can see that its broken in graph view, or simply by clicking the links (itll complain about folder existing rather than bring you to the file)

I’ll probably open another PR for unit testing and a little more refactoring for this function. 