### PR TITLE
feat : spaceEncode, to make it look better.

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -268,6 +268,9 @@ export default class Waypoint extends Plugin {
 		return null;
 	}
 
+  spaceEncode(str: string) {
+		return str.replace(/ /g, "%20");
+	}
 	/**
 	 * Generate an encoded URI path to the given file that is relative to the given root.
 	 * @param rootNode The from which the relative path will be generated
@@ -276,9 +279,9 @@ export default class Waypoint extends Plugin {
 	 */
 	getEncodedUri(rootNode: TFolder, node: TAbstractFile) {
 		if (rootNode.isRoot()) {
-			return `./${encodeURI(node.path)}`;
+			return `./${this.spaceEncode(node.path)}`;
 		}
-		return `./${encodeURI(node.path.substring(rootNode.path.length + 1))}`;
+		return `./${this.spaceEncode(node.path.substring(rootNode.path.length + 1))}`;
 	}
 
 	/**


### PR DESCRIPTION
The Obsidian supports URLs in various languages in the UTF-8 manner.
However, too strict a method of changing the URL of the code URI() reduces the readability of the MD file itself.
So I changed only the space that prevents the link from working to %20.



If you think there's a problem with this method, please let me know what the problem is in detail.
I passed my test.

![image](https://user-images.githubusercontent.com/61359316/210500719-53d81e4c-61bf-4e96-abc0-95122dbc6586.png)
![image](https://user-images.githubusercontent.com/61359316/210500783-3c092ff4-add6-47d0-b11f-6bd1a521e317.png)

I'm sorry if I was rude. It hasn't been long since I developed it.