### PR TITLE
Support for indenting with spaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "waypoint",
-	"version": "1.3.0",
+	"version": "1.4.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "waypoint",
-			"version": "1.3.0",
+			"version": "1.4.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/codemirror": "^5.60.5",


### PR DESCRIPTION
Resolves: https://github.com/IdreesInc/Waypoint/issues/14

- adds `useSpaces` to WaypointSettings with a default of false to preserve previous default (tabs)
- adds `numSpaces` to WaypointSettings to designate how many spaces to use when spaces is enabled
- adds a toggle setting to enable/disable the use of spaces
- adds a text input setting to allow user customization of the number of spaces to use
- modifies `getFileTreeRepresentation` to use spaces or tabs