### PR TITLE
Add support for JohnnyDecimal folder structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Waypoint is an Obsidian plugin that automatically generates tables of contents/M
 - **Permanent and portable**
 	- Unlike other plugins, Waypoints are generated and saved as real markdown text within your folder notes. If you decide to switch to a different markdown editor that supports [[links]], all of your tables of contents will still be usable.
 	- Note that the Waypoint plugin currently only works with Obsidian, so moving files around in another editor will cause your waypoints to be out-of-date.
+- **Support Johnny Decimal Folder Structure**
+	- [Johnny Decimal](https://johnnydecimal.com/) folder structure depends mainly on numbering your folders. So your folder name could start with numbers. At the same time, you don't like adding this number to the Folder Note name.
+	- This feature allows to have your Parent folder numbered, while your Folder Note doesn't not.
 
 ## How To Use
 


### PR DESCRIPTION
# Support Johnny Decimal folder structure

## Overview

This feature allows users who adapt Johnny Decimal folder structure, which is numbering their folder names, to have the flexibility to set their Folder Note without this numbering system.
However, it doesn't strictly require all folders to have numbers, so folders that have the exact name as the folder note will still pass through.

## Changes

### `README.md`:

    Added a new section "Ordering Notes on Waypoint" explaining how users can order their notes in the generated waypoints by specifying waypointPriority in the frontmatter of their notes.

### `main.ts`:

- Add flag `useJohnnyDecimal` to handle folders with numbering system.
- Created helper method `removeJohnnyDecimal` to return the parent folder without the numbers, if found.
- Update `IsFolderNote` and `getFileTreeRepresentation` functions to support Johnny Decimal feature

### `README.md`

- Added a description for the newly introduced feature.
