### PR TITLE
Added Option to specify custom FolderNote Filename

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "waypoint",
-	"version": "1.3.0",
+	"version": "1.4.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "waypoint",
-			"version": "1.3.0",
+			"version": "1.4.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/codemirror": "^5.60.5",


### PR DESCRIPTION
Added  new Folder Note Style option: "Custom Filename" which allows user to specify the filename of their folder note. 
<img width="534" alt="image" src="https://github.com/IdreesInc/Waypoint/assets/56354081/8b7f9cf6-1731-4452-a46f-43aa5b585098">
<img width="598" alt="image" src="https://github.com/IdreesInc/Waypoint/assets/56354081/00f0df68-6d93-494c-acec-aa5e4eb001a4">
