### PR TITLE
Bug Fix - use wikilinks for folder note entries when option is enabled

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -310,8 +310,9 @@ export default class Waypoint extends Plugin {
 			if (folderNote instanceof TFile) {
 				if (this.settings.useWikiLinks) {
 					text = `${bullet} **[[${folderNote.basename}]]**`;
+				} else {
+					text = `${bullet} **[${folderNote.basename}](${this.getEncodedUri(rootNode, folderNote)})**`;
 				}
-				text = `${bullet} **[${folderNote.basename}](${this.getEncodedUri(rootNode, folderNote)})**`;
 				if (!topLevel) {
 					if (this.settings.stopScanAtFolderNotes) {
 						return text;


### PR DESCRIPTION
Fixes a line of code that was overwriting a `text` variable such that it would never generate using wiki style links syntax. Specifically, this is in the section of code generating the links to a folder's "folder note".