### PR TITLE
Add Option to generate Obsidian URLs in Landmark Subdirectories

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -341,8 +341,7 @@ export default class Waypoint extends Plugin {
 			if (folderNote instanceof TFile) {
 				if (landmarkObsidianLink) {
 					text = `${bullet} **[${folderNote.basename}](obsidian://open?vault=${this.app.vault.getName()}&file=${this.getEncodedUri(rootNode, folderNote)})**`;
-				}
-				else if (this.settings.useWikiLinks) {
+				} else if (this.settings.useWikiLinks) {
 					text = `${bullet} **[[${folderNote.basename}]]**`;
 				} else {
 					text = `${bullet} **[${folderNote.basename}](${this.getEncodedUri(rootNode, folderNote)})**`;


### PR DESCRIPTION
Apologies for the title, but I'm having trouble succiently describing it. 

I like how Waypoint automatically generates a Table of Content, but unfortunately it links sub-sub-directories with the top directory. Of course I could place Waypoints and sever the links, but it diminishes the Table of Contents aspect a bit. I did a little research and to my understanding there seems to be only one way to [link to another file without connecting them on the graph](https://forum.obsidian.md/t/hide-specific-links-in-graph/27802/2): `obsidian://open?vault=[VAULT NAME]&file=[FILE NAME]`.

Quickly hacked something together. Added another bool to `getFileTreeRepresentation` that defaults to false. During the `folderNote` section, if the setting is enabled and a landmark is in the file, set bool to true, and subsequent recursions will generate the Obsidian URL instead of MD/Wiki Links.

Results are a graph that looks identical to one with sub-directory Waypoints and table of contents that is close to one without sub-directory Waypoints, the difference beings the links. Functionally close to a MD/Wiki Link except no middle clicking new tab, dragging to tab, and likely other convenience features that come with native links. Settings description could probably use some work.

Breaks your portable "rule" in the README, so I would understand if this were rejected. Links useless if moved out of current vault/need to be regenerated.

Child 1 & 2 are using Landmarks, Child Waypoint is using a Waypoint. Based off brief testing I don't think I broke anything.

![graph](https://github.com/IdreesInc/Waypoint/assets/80072393/e2c6841e-4e5f-4f3c-ab33-2c03580e0f7a)
![ToC](https://github.com/IdreesInc/Waypoint/assets/80072393/210516ed-f7e4-4d27-b8e6-dea5834591f9)
![Landmark](https://github.com/IdreesInc/Waypoint/assets/80072393/d216b925-70d2-40b7-9435-2b0134d9f5c7)
Landmarks themselves still generate MD/Wiki Links, its just higher level Waypoints don't.

