### PR TITLE
fix: Fix locating parent point

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -448,6 +448,9 @@ export default class Waypoint extends Plugin {
 	async locateParentPoint(node: TAbstractFile, includeCurrentNode: boolean): Promise<[WaypointType, TFile]> {
 		this.log("Locating parent flag and file of " + node.name);
 		let folder = includeCurrentNode ? node : node.parent;
+		if (this.settings.folderNoteType === FolderNoteType.InsideFolder) {
+			folder = folder?.parent;
+		}
 		while (folder) {
 			let folderNote;
 			if (this.settings.folderNoteType === FolderNoteType.InsideFolder) {


### PR DESCRIPTION
Resolves #113 

The issue occurs when we are in "Folder Name Inside" mode of the Folder Note plugin. In this case, we will want to go up one extra folder path in the tree.